### PR TITLE
parse array and union-array types in data_type using proper grammar rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Added
 
+- Support array and union-array types in data_type
+
 ## [0.7.0] - 2026-01-11
 
 # Added

--- a/pycep/bicep.lark
+++ b/pycep/bicep.lark
@@ -51,7 +51,10 @@ child_resource: "resource" STRING QUOTED_INTERPOLATION [EXISTING] "=" (object | 
 
 // element type extras
 
-data_type: STRING
+data_type: base_type array_suffix*
+base_type: STRING | union_type
+union_type: "(" data_type ("|" data_type)+ ")"
+array_suffix: "[" "]"
 
 type_api_pair: QUOTED_INTERPOLATION
 

--- a/pycep/transformer.py
+++ b/pycep/transformer.py
@@ -396,8 +396,22 @@ class BicepToJson(Transformer[Token, pycep_typing.BicepJson]):
     #
     ####################
 
-    def data_type(self, arg: tuple[Token]) -> str:
-        return str(arg[0])
+    def array_suffix(self, args: list[Any]) -> None:
+        return None  # presence counts; value is unused
+
+    def base_type(self, args: list[Any]) -> pycep_typing.DataType:
+        result = args[0]
+        return str(result) if isinstance(result, Token) else result
+
+    def union_type(self, args: list[pycep_typing.DataType]) -> pycep_typing.UnionType:
+        return {"type": "union", "members": list(args)}
+
+    def data_type(self, args: list[Any]) -> pycep_typing.DataType:
+        base, *suffixes = args
+        result: pycep_typing.DataType = base
+        for _ in suffixes:
+            result = {"type": "array", "item_type": result}
+        return result
 
     def type_api_pair(self, args: tuple[Token, Token]) -> pycep_typing.ApiTypeVersion:
         type_name, api_version = str(args[0])[1:-1].split("@")

--- a/pycep/transformer.py
+++ b/pycep/transformer.py
@@ -396,7 +396,7 @@ class BicepToJson(Transformer[Token, pycep_typing.BicepJson]):
     #
     ####################
 
-    def array_suffix(self, args: list[Any]) -> None:
+    def array_suffix(self, _: list[Any]) -> None:
         return None  # presence counts; value is unused
 
     def base_type(self, args: list[Any]) -> pycep_typing.DataType:

--- a/pycep/typing.py
+++ b/pycep/typing.py
@@ -7,6 +7,8 @@ from typing_extensions import NotRequired
 PossibleValue: TypeAlias = "bool | int | str | list[bool | int | str] | dict[str, PossibleValue]"
 PossibleNoneValue: TypeAlias = "PossibleValue | None"  # noqa: TC008
 
+DataType: TypeAlias = "str | ArrayType | UnionType"
+
 ModulePath: TypeAlias = "LocalModulePath | BicepRegistryModulePath | BicepRegistryAliasModulePath | TemplateSpecModulePath | TemplateSpecAliasModulePath"
 ModuleDetail: TypeAlias = "_LocalModulePathDetail | _BicepRegistryModulePathDetail | _BicepRegistryAliasModulePathDetail | _TemplateSpecModulePathDetail | _TemplateSpecAliasModulePathDetail"
 LoopType: TypeAlias = "LoopArray | LoopArrayIndex | LoopObject | LoopRange"
@@ -32,6 +34,23 @@ ResourceFunctions: TypeAlias = "ExtensionResourceId | ListFunc | ManagementGroup
 ScopeFunctions: TypeAlias = "ManagementGroup | ResourceGroup | Subscription | Tenant"
 StringFunctions: TypeAlias = "Base64 | Base64ToJson | Base64ToString | DataUri | DataUriToString | EndsWith | Format | Guid | IndexOf | Join | LastIndexOf | NewGuid | PadLeft | Replace | Split | StartsWith | String | Substring | ToLower | ToUpper | Trim | UniqueString | Uri | UriComponent | UriComponentToString"
 Functions: TypeAlias = "AnyFunctions | ArrayFunctions | DateFunctions | DeploymentFunctions | FileFunctions | LambdaFunctions | LogicalFunctions | NumericFunctions | ObjectFunctions | ResourceFunctions | ScopeFunctions | StringFunctions | UnknownFunction"
+
+
+####################
+#
+# Data types
+#
+####################
+
+
+class ArrayType(TypedDict):
+    type: Literal["array"]
+    item_type: "DataType"
+
+
+class UnionType(TypedDict):
+    type: Literal["union"]
+    members: "list[DataType]"
 
 
 ####################
@@ -118,7 +137,7 @@ class ExtensionResponse(TypedDict):
 
 class ParameterAttributes(TypedDict):
     decorators: list[Decorator]
-    type: str
+    type: DataType
     default: PossibleNoneValue
     __start_line__: NotRequired[int]
     __end_line__: NotRequired[int]
@@ -135,7 +154,7 @@ class ParamResponse(TypedDict):
 
 class VariableAttributes(TypedDict):
     decorators: list[Decorator]
-    type: NotRequired[str]
+    type: NotRequired[DataType]
     value: PossibleValue
     __start_line__: NotRequired[int]
     __end_line__: NotRequired[int]
@@ -152,7 +171,7 @@ class VarResponse(TypedDict):
 
 class OutputAttributes(TypedDict):
     decorators: list[Decorator]
-    type: str
+    type: DataType
     value: PossibleValue
     __start_line__: NotRequired[int]
     __end_line__: NotRequired[int]
@@ -223,8 +242,8 @@ class TypeResponse(TypedDict):
 
 class FunctionAttributes(TypedDict):
     decorators: list[Decorator]
-    args: dict[str, str]
-    type: str
+    args: dict[str, DataType]
+    type: DataType
     expression: PossibleValue
     __start_line__: NotRequired[int]
     __end_line__: NotRequired[int]

--- a/pycep/typing.py
+++ b/pycep/typing.py
@@ -45,12 +45,12 @@ Functions: TypeAlias = "AnyFunctions | ArrayFunctions | DateFunctions | Deployme
 
 class ArrayType(TypedDict):
     type: Literal["array"]
-    item_type: "DataType"
+    item_type: DataType
 
 
 class UnionType(TypedDict):
     type: Literal["union"]
-    members: "list[DataType]"
+    members: list[DataType]
 
 
 ####################

--- a/tests/examples/basic/01-param-array-type/main.bicep
+++ b/tests/examples/basic/01-param-array-type/main.bicep
@@ -1,0 +1,8 @@
+// simple array type
+param simpleArray string[]
+
+// nested array type
+param nestedArray string[][]
+
+// union array type
+param unionArray (int | string)[]

--- a/tests/examples/basic/01-param-array-type/result.json
+++ b/tests/examples/basic/01-param-array-type/result.json
@@ -1,0 +1,39 @@
+{
+  "globals": {
+    "scope": {
+      "value": "resourceGroup"
+    }
+  },
+  "parameters": {
+    "simpleArray": {
+      "decorators": [],
+      "type": {
+        "type": "array",
+        "item_type": "string"
+      },
+      "default": null
+    },
+    "nestedArray": {
+      "decorators": [],
+      "type": {
+        "type": "array",
+        "item_type": {
+          "type": "array",
+          "item_type": "string"
+        }
+      },
+      "default": null
+    },
+    "unionArray": {
+      "decorators": [],
+      "type": {
+        "type": "array",
+        "item_type": {
+          "type": "union",
+          "members": ["int", "string"]
+        }
+      },
+      "default": null
+    }
+  }
+}

--- a/tests/test_parse_general.py
+++ b/tests/test_parse_general.py
@@ -280,3 +280,16 @@ def test_parse_type_decorator() -> None:
 
     # then
     assert_that(result).is_equal_to(expected_result)
+
+
+def test_parse_param_array_type() -> None:
+    # given
+    sub_dir_path = EXAMPLES_DIR / "basic/01-param-array-type"
+    file_path = sub_dir_path / "main.bicep"
+    expected_result = json.loads((sub_dir_path / "result.json").read_text())
+
+    # when
+    result = BICEP_PARSER.parse(file_path=file_path)
+
+    # then
+    assert_that(result).is_equal_to(expected_result)


### PR DESCRIPTION
Replaced ad-hoc regex terminals with idiomatic Lark grammar rules:

      data_type: base_type array_suffix*
      base_type: STRING | union_type
      union_type: "(" data_type ("|" data_type)+ ")"
      array_suffix: "[" "]"

  This correctly handles string[], string[][], and (int | string)[] (and
  any depth/combination) without regex. The structured parse
  tree is reflected in the output: simple types remain plain strings while
  array and union-array types become typed dicts — {"type": "array",
  "item_type": ...} and {"type": "union", "members": [...]} — consistent
  with how the rest of the AST is represented.

  Add ArrayType / UnionType TypedDicts and a DataType alias to typing.py;
  update all four element attributes that carry a data_type result
  (ParameterAttributes, OutputAttributes, VariableAttributes,
  FunctionAttributes). Add array_suffix / base_type / union_type
  transformer handlers and rewrite data_type to wrap depth iteratively.
  No existing test fixtures change since plain-type params/outputs/funcs
  still resolve to plain strings.